### PR TITLE
Update tutorial to reflect rails 4 `set_model` private method

### DIFF
--- a/_posts/2015-12-01-rails-girls-app-tutorial-2.markdown
+++ b/_posts/2015-12-01-rails-girls-app-tutorial-2.markdown
@@ -71,17 +71,22 @@ Adicione:
 <%= render 'comments/form' %>
 {% endhighlight %}
 
-Em `app/controllers/ideas_controller.rb` adicione a *action* **show** abaixo da linha seguinte:
+Em `app/controllers/ideas_controller.rb`, no final do arquivo, você encontrará o método `set_idea`:
 
 {% highlight ruby %}
-@idea = Idea.find(params[:id])
+def set_idea
+  @idea = Idea.find(params[:id])
+end
 {% endhighlight %}
 
-Adicione:
+Modifique-o para:
 
 {% highlight ruby %}
-@comments = @idea.comments.all
-@comment = @idea.comments.build
+def set_idea
+  @idea = Idea.find(params[:id])
+  @comments = @idea.comments.all
+  @comment = @idea.comments.build
+end
 {% endhighlight %}
 
 Abra `app/views/comments/_form.html.erb` e após:


### PR DESCRIPTION
Rails 4 generate a `set_idea` method on its default scaffold. This PR aims to clarify where the user should put the code in the `IdeaController`
