### PR TITLE
Add note on regenerate thumbnails

### DIFF
--- a/_posts/2015-12-11-miniaturas.markdown
+++ b/_posts/2015-12-11-miniaturas.markdown
@@ -148,3 +148,10 @@ Para:
 
 
 Agora abra no navegador na página [http://localhost:3000/ideas](http://localhost:3000/ideas){:target="_blank"} e verifique se as miniaturas estão sendo exibidas.
+
+> Nota: Caso várias ideias já tenham sido criadas, você precisará gerar suas miniaturas executando os seguintes comandos:
+
+{% highlight ruby %}
+rails console
+Idea.all.each { |idea| idea.picture.recreate_versions! }
+{% endhighlight %}


### PR DESCRIPTION
At the 7th step of the tutorial, the users are asked to add a thumbnail version of their images. If they already created some ideas with images, they need to run Carrierwave `#recreate_versions!` method to successfully generate image versions on existent images.
